### PR TITLE
Removing event grid client package

### DIFF
--- a/.github/workflows/developrelease.yml
+++ b/.github/workflows/developrelease.yml
@@ -1,0 +1,33 @@
+name: Build, Test and Release a Beta version
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.301
+    - name: Install dependencies
+      run: dotnet restore ./AzureFunctions.EventGrid/AzureFunctions.EventGrid.csproj
+    - name: Build
+      run: dotnet build ./AzureFunctions.EventGrid/AzureFunctions.EventGrid.csproj --configuration Release --no-restore
+    - name: Test
+      run: dotnet test ./AzureFunctions.EventGrid/AzureFunctions.EventGrid.csproj --no-restore --verbosity normal
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        prerelease: true
+    

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: Build, Test & Release to Nuget from master branch
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Fetch all history for all tags and branches
+      run: git fetch --unshallow || true
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v0.9.4
+      with:
+          versionSpec: '5.3.x'
+    - name: Use GitVersion
+      id: gitversion # step id used as reference for output values
+      uses: gittools/actions/gitversion/execute@v0.9.4
+    - run: |
+        echo "NuGetVersion: ${{ steps.gitversion.outputs.nuGetVersion }}"
+        echo "NuGetPreReleaseTagV2: ${{ steps.gitversion.outputs.CommitsSinceVersionSourcePadded }}"
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.301
+    - name: Install dependencies
+      run: dotnet restore ./AzureFunctions.EventGrid/AzureFunctions.EventGrid.csproj
+    - name: Build
+      run: dotnet build ./AzureFunctions.EventGrid/AzureFunctions.EventGrid.csproj --configuration Release --no-restore
+    - name: Test
+      run: dotnet test ./AzureFunctions.EventGrid/AzureFunctions.EventGrid.csproj --no-restore --verbosity normal
+    - name: Publish NuGet
+      uses: brandedoutcast/publish-nuget@v2.5.5
+      with:
+        PROJECT_FILE_PATH: ./AzureFunctions.EventGrid/AzureFunctions.EventGrid.csproj
+        VERSION_STATIC: ${{ steps.gitversion.outputs.nuGetVersion }}-${{ steps.gitversion.outputs.CommitsSinceVersionSourcePadded }}
+        NUGET_KEY: ${{secrets.NUGET_KEY}}
+

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -1,0 +1,23 @@
+name: Build & Test
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.301
+    - name: Install dependencies
+      run: dotnet restore ./AzureFunctions.EventGrid/AzureFunctions.EventGrid.csproj
+    - name: Build
+      run: dotnet build ./AzureFunctions.EventGrid/AzureFunctions.EventGrid.csproj --configuration Release --no-restore
+    - name: Test
+      run: dotnet test ./AzureFunctions.EventGrid/AzureFunctions.EventGrid.csproj --no-restore --verbosity normal

--- a/AzureFunctions.EventGrid/AzureFunctions.EventGrid.csproj
+++ b/AzureFunctions.EventGrid/AzureFunctions.EventGrid.csproj
@@ -16,7 +16,6 @@ You can specify all necessary event details you need.</Description>
     <PackageIcon>icon-logo.png</PackageIcon>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.EventGrid" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/AzureFunctions.EventGrid/EventGridAttribute.cs
+++ b/AzureFunctions.EventGrid/EventGridAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 using Microsoft.Azure.WebJobs.Description;
 
 namespace AzureFunctions.EventGrid
@@ -20,5 +21,10 @@ namespace AzureFunctions.EventGrid
         /// </summary>
         [AppSetting]
         public string TopicKey { get; set; }
+
+        /// <summary>
+        /// If you have already instantiated an <seealso cref="System.Net.Http.HttpClient"/>, pass it to this property.
+        /// </summary>
+        public HttpClient HttpClient { get; set; }
     }
 }

--- a/AzureFunctions.EventGrid/EventGridModel.cs
+++ b/AzureFunctions.EventGrid/EventGridModel.cs
@@ -2,7 +2,7 @@
 
 namespace AzureFunctions.EventGrid
 {
-    class EventGridModel :Event
+    internal class EventGridModel :Event
     {
         //
         // Summary:

--- a/AzureFunctions.EventGrid/EventGridModel.cs
+++ b/AzureFunctions.EventGrid/EventGridModel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace AzureFunctions.EventGrid
+{
+    class EventGridModel :Event
+    {
+        //
+        // Summary:
+        //     Gets or sets an unique identifier for the event.
+        public string Id { get; set; }
+
+        //
+        // Summary:
+        //     Gets or sets the time (in UTC) the event was generated.
+        public DateTime EventTime { get; set; }
+
+        public EventGridModel(string id,string subject, string dataVersion, string eventType, object data,DateTime eventTime)
+        {
+            this.Id = id;
+            this.Subject = subject;
+            this.DataVersion = dataVersion;
+            this.EventType = eventType;
+            this.Data = data;
+            this.EventTime = eventTime;
+        }
+    }
+}


### PR DESCRIPTION
Addressing https://github.com/Jandev/azurefunctions-eventgrid/issues/12

- I created this PR on top of https://github.com/Jandev/azurefunctions-eventgrid/pull/15 . So please merge the it before approving this PR.

Few things to consider in this PR:

- I've assumed that the `TopicEndpoint` will be provided with the api-version, which means the config settings will looks like 

```json
{
"EventGridBindingSampleTopicEndpoint": "https://<name>.eventgrid.azure.net/api/events?api-version=2018-01-01"
}
```

- I've created a new model called `EventGridModel` by inheriting the `Event` class. so that existing code won't break